### PR TITLE
Split server services

### DIFF
--- a/cameraApp/src/Detection/siginify-analyzer.js
+++ b/cameraApp/src/Detection/siginify-analyzer.js
@@ -3,11 +3,25 @@ class SignifyDetectionAnalyzer {
   constructor(detection_model) {
     this.detection_model = detection_model;
     this.stable_handRect = this.new_handRect = UN_DETECTED_HANDS;
+    this.sign_res = undefined;
   }
 
-  async detectHandSign(img) {
+  async detectHands(img) {
     try {
-      this.latest_res = await this.detection_model.detect(img);
+      this.latest_res = await this.detection_model.detectHands(img);
+      this.update_hands();
+      return this.latest_res;
+    } catch (e) {
+      this.latest_res = EMPTY_RESULTS;
+      this.stable_handRect = this.new_handRect = UN_DETECTED_HANDS;
+      this.latest_res.error = e.to_string();
+      throw e;
+    }
+  }
+
+  async detectSign(img) {
+    try {
+      this.latest_res = await this.detection_model.detectSign(img);
       this.update_hands();
       return this.latest_res;
     } catch (e) {

--- a/cameraApp/src/Detection/signify-web-api.js
+++ b/cameraApp/src/Detection/signify-web-api.js
@@ -1,14 +1,19 @@
 import {Exception, HttpMethod, http_method} from '../Network/httpClient';
+class SignifyApiPath {
+  static DETECT_HANDS = 'api/img/DetectHands';
+  static DETECT_SIGN = 'api/img/DetectHandsSign';
+}
 class SignifyWebDetectionModel {
-  constructor(ip, port) {
+  constructor(ip, port, apiPath = SignifyApiPath) {
     this.ip = ip;
     this.port = port;
+    this.apiPath = apiPath;
   }
 
-  async detect(img) {
+  async sendRequest(path, img) {
     try {
       return await http_method(
-        `http://${this.ip}:${this.port}/api/img`,
+        `http://${this.ip}:${this.port}/${path}`,
         HttpMethod.POST,
         {img: img},
         2000,
@@ -16,6 +21,14 @@ class SignifyWebDetectionModel {
     } catch (err) {
       throw new Exception('cant reach Server');
     }
+  }
+
+  detectSign(img) {
+    return this.sendRequest(this.apiPath.DETECT_SIGN, img);
+  }
+
+  detectHands(img) {
+    return this.sendRequest(this.apiPath.DETECT_HANDS, img);
   }
 }
 

--- a/cameraApp/src/components/Pages/CameraPage.js
+++ b/cameraApp/src/components/Pages/CameraPage.js
@@ -9,7 +9,9 @@ const CameraPage = () => {
   const onDetection = useCallback(res => {
     const error = res.error;
     setErrorText(error);
-    setDetectedChar(res.sign.char);
+    //res.sign != undefined when the camera tried to detect the letter
+    //otherwise is just the hand rect
+    if (res.sign) setDetectedChar(res.sign.char);
   }, []);
   const detectedTextStyle = useMemo(() => {
     return detectedChar != EMPTY_SIGN
@@ -22,7 +24,7 @@ const CameraPage = () => {
       <SignifyCamera
         onDetection={onDetection}
         style={styles.camera}
-        frameProcessorFps={6}
+        frameProcessorFps={5}
         frameMaxSize={220}
         frameQuality={30}
       />

--- a/tsWebServer/index.ts
+++ b/tsWebServer/index.ts
@@ -1,8 +1,10 @@
 import { Pool } from "./src/pool/pool.js";
 import { shutDown } from "./src/util/shutDown.js";
 import { Request, Response } from "express";
+import { DetectType } from './src/detection/DetectType.js'
 import express from "express";
-
+import { executePoolRequest } from './src/server/services.js'
+console.log(DetectType)
 const app = express();
 const PORT = 3000;
 const CHILD_NUM = 1;
@@ -11,19 +13,23 @@ const PROCESS_NAME = "../SignifyService/signifyService.py";
 
 const pool = new Pool(CHILD_NUM, PROCESS_NAME);
 
+
 app.use(express.json({ limit: "50mb" }));
+
+
 
 app.get("/", (_: Request, res: Response) => {
   res.send("hello world");
 });
 
-app.post("/api/img", async (req: Request, res: Response) => {
-  pool
-    .exec(req.body.img)
-    .then((data) => {
-      res.send(data);
-    })
-    .catch((err) => res.send(err));
+app.post("/api/img/DetectHands", async (req: Request, res: Response) => {
+  console.log("In Detect Hands");
+  executePoolRequest(pool, DetectType.Hands, req, res)
+})
+
+app.post("/api/img/DetectHandsSign", async (req: Request, res: Response) => {
+  console.log("In Detect Sign");
+  executePoolRequest(pool, DetectType.HandsSign, req, res)
 });
 
 pool.workersReady(true).then(() => {

--- a/tsWebServer/src/detection/DetectType.ts
+++ b/tsWebServer/src/detection/DetectType.ts
@@ -1,0 +1,6 @@
+enum DetectType {
+    Hands = "Hands",
+    HandsSign = "HandsSign"
+}
+
+export { DetectType }

--- a/tsWebServer/src/pool/pool.ts
+++ b/tsWebServer/src/pool/pool.ts
@@ -46,10 +46,10 @@ class Pool {
   }
 
   private runWorker(worker: PyProc, task: Task) {
-    const { img, resolve, reject } = task;
+    const { request, img, resolve, reject } = task;
     worker.free = false;
     worker
-      .run(img)
+      .run(request, img)
       .then((res) => resolve(res))
       .catch((err) => reject(err))
       .finally(() => {
@@ -92,14 +92,14 @@ class Pool {
     });
   }
 
-  exec(img: string): Promise<string> {
+  exec(request: string, img: string): Promise<string> {
     return new Promise((resolve, reject) => {
       if (this._timeOut) {
         setTimeout(() => reject("time out"), this._timeOut);
       }
 
       const worker = this._workers.find((w) => w.free);
-      const task = { img, resolve, reject };
+      const task = { request, img, resolve, reject };
       if (worker) {
         this.runWorker(worker, task);
       } else {

--- a/tsWebServer/src/pool/pyProc/getRecognition.ts
+++ b/tsWebServer/src/pool/pyProc/getRecognition.ts
@@ -6,6 +6,7 @@ const decoder = new StringDecoder("utf8");
 const FINISHED_READING = "finished";
 
 const getRecognitionPromise = (
+  request: string,
   img: string,
   child: ChildProcess
 ): Promise<string> => {
@@ -22,6 +23,7 @@ const getRecognitionPromise = (
     };
 
     child.stdout!.on("data", listener);
+    child.stdin!.write(request.replace(/\s/g, "") + "\n");
     child.stdin!.write(img.replace(/\s/g, "") + "\n");
 
     bus.once(FINISHED_READING, () => {

--- a/tsWebServer/src/pool/pyProc/pyProc.ts
+++ b/tsWebServer/src/pool/pyProc/pyProc.ts
@@ -53,7 +53,7 @@ class PyProc {
     });
   }
 
-  run(img: string, timeOut: number | undefined = undefined): Promise<string> {
+  run(request: string, img: string, timeOut: number | undefined = undefined): Promise<string> {
     if (!this._ready) {
       throw "Process is not ready! await waitForSpwan() to be ready";
     }
@@ -61,6 +61,7 @@ class PyProc {
     if (this._killed) {
       throw "Process is killed!";
     }
+
 
     return new Promise((resolve, reject) => {
       let timeoutid: any = undefined;
@@ -71,7 +72,7 @@ class PyProc {
         }, timeOut);
       }
 
-      getRecognitionPromise(img, this._child)
+      getRecognitionPromise(request, img, this._child)
         .then((res) => resolve(res))
         .catch((err) => reject(err))
         .finally(() => clearTimeout(timeoutid));

--- a/tsWebServer/src/pool/types.ts
+++ b/tsWebServer/src/pool/types.ts
@@ -1,4 +1,5 @@
 interface Task {
+  request: string;
   img: string;
   resolve: (param: string | PromiseLike<string>) => void;
   reject: (reason?: any) => void;

--- a/tsWebServer/src/server/services.ts
+++ b/tsWebServer/src/server/services.ts
@@ -1,0 +1,14 @@
+import { DetectType } from '../detection/DetectType.js'
+import { Pool } from '../pool/pool.js'
+import { Request, Response } from "express";
+
+const executePoolRequest = (pool: Pool, reqType: DetectType, req: Request, res: Response) => {
+    pool
+        .exec(reqType, req.body.img)
+        .then((data) => {
+            res.send(data);
+        })
+        .catch((err) => res.send(err));
+}
+
+export { executePoolRequest }


### PR DESCRIPTION
1.split the img api in the ts server to two apis (one for detect hands,one for detect sign +hands cus detect hands is cheap anyway)
2.updated the signifyService.py ==> now its recive request (hands, hands+sign) and the img as input
      if request = hands its return only the rectangle of the hands
      if request = hands+sign its return the reactangle of the hands + detecing the sign 
3. updated the reactNative  to support the two apis 
  now the frameProcessorFps property of signifyCamera works like that:
   the first and the last frame it will detect hands + sign (which is expensive)
   and in the middle frames it will detect only the reactangle/
example: frameProcessorFps = 5
 first frame it will detect hands + sign , 3 frames letter only hands , last frame hands + sign again
**** in the future i will allow to send more hands + sign requests by paremter and not fix to the first and last frame.
fix #65