### PR TITLE
adding google translate api class

### DIFF
--- a/cameraApp/src/Api/google-translate-default-api.js
+++ b/cameraApp/src/Api/google-translate-default-api.js
@@ -1,0 +1,5 @@
+import {GoogleCloudTranslateApi} from './google-translate-text';
+import {translate_key} from '../../secrets';
+const google_translator = new GoogleCloudTranslateApi(translate_key);
+
+module.exports = {google_translator};

--- a/cameraApp/src/Api/google-translate-text.js
+++ b/cameraApp/src/Api/google-translate-text.js
@@ -1,0 +1,37 @@
+import {Exception, http_method} from '../Network/httpClient';
+class GoogleTranslateApiPath {
+  constructor(key) {
+    this.key = key;
+  }
+  create_path(text, target_lang) {
+    return `https://translation.googleapis.com/language/translate/v2?key=${this.key}&target=${target_lang}&q=${text}`;
+  }
+}
+
+class GoogleCloudTranslateApi {
+  constructor(key) {
+    this.path_builder = new GoogleTranslateApiPath(key);
+  }
+
+  async translate(text, language_translate_to) {
+    try {
+      translate_obj = await http_method(
+        this.path_builder.create_path(text, language_translate_to),
+      );
+      if (!translate_obj.data || translate_obj.data.translations.length == 0) {
+        return {error: new Exception('api didnt return right objet')};
+      }
+      const translate_data = translate_obj.data.translations[0];
+      return {
+        sourceLanguage: translate_data.detectedSourceLanguage,
+        targetLanguage: language_translate_to,
+        source: text,
+        translated_text: translate_data.translatedText,
+      };
+    } catch (err) {
+      return {error: err};
+    }
+  }
+}
+
+module.exports = {GoogleCloudTranslateApi};


### PR DESCRIPTION
import {google_translator} from '../../Api/google-translate-default-api';
      translate_obj = await google_translator.translate('sup', 'fr');
      if (meow.error) {
        console.log(meow.error.to_string());
      }

to use this we need api key (right now its disabled cus it can cost money, i will test it and we will add it before showing it 
in september)